### PR TITLE
feat: add method to calculate the root of the tree only

### DIFF
--- a/src/test_xor128.rs
+++ b/src/test_xor128.rs
@@ -568,6 +568,37 @@ fn test_from_iter() {
 }
 
 #[test]
+fn test_root_from_iter() {
+    let mut a = XOR128::new();
+
+    let root = MerkleTree::<[u8; 16], XOR128, VecStore<_>>::try_root_from_iter(
+        ["a", "b", "c", "d"].iter().map(|x| {
+            a.reset();
+            x.hash(&mut a);
+            Ok(a.hash())
+        }),
+    )
+    .unwrap();
+    assert_eq!(root, [1, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
+fn test_root_from_iter_large() {
+    let mut a = XOR128::new();
+    let count = SMALL_TREE_BUILD * SMALL_TREE_BUILD * 128;
+
+    let root =
+        MerkleTree::<[u8; 16], XOR128, MmapStore<_>>::try_root_from_iter((0..count).map(|x| {
+            a.reset();
+            x.hash(&mut a);
+            93.hash(&mut a);
+            Ok(a.hash())
+        }))
+        .unwrap();
+    assert_eq!(root, [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
+}
+
+#[test]
 fn test_simple_tree() {
     let answer: Vec<Vec<[u8; 16]>> = vec![
         vec![


### PR DESCRIPTION
With `MerkleTree::try_root_from_iter()` it's possible to calculate the root
of a merkle tree without storing the intermediary data. This process takes
very little memory (approx. item_size * height * branch_factor).