### PR TITLE
Implementing additional SHA256-based hasher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ byteorder = "1.3.1"
 env_logger = "0.7.1"
 
 [features]
-default = []
+default = ["rust-crypto"]
 bitcoin = ["ring", "rust-crypto"]
 chaincore = ["rust-crypto"]
 crypto_bench = ["rust-crypto", "ring"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,10 @@ typenum = "1.11.2"
 [dev-dependencies]
 byteorder = "1.3.1"
 env_logger = "0.7.1"
+rust-crypto = "^0.2.36"
 
 [features]
-default = ["rust-crypto"]
+default = []
 bitcoin = ["ring", "rust-crypto"]
 chaincore = ["rust-crypto"]
 crypto_bench = ["rust-crypto", "ring"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,19 +102,15 @@ pub mod merkle;
 pub mod test_common;
 
 /// Tests XOR128.
-#[cfg(test)]
 mod test_xor128;
 
 /// Tests data.
-#[cfg(test)]
 mod test_item;
 
 /// Tests SIP.
-#[cfg(test)]
 mod test_sip;
 
 /// Tests for Merkle Hasher Customization.
-#[cfg(test)]
 mod test_cmh;
 
 #[macro_use]

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -1,5 +1,5 @@
 use crate::hash::{Algorithm, Hashable};
-use crate::merkle::get_merkle_proof_lemma_len;
+use crate::merkle::{get_merkle_proof_lemma_len, Element};
 
 use anyhow::Result;
 use std::marker::PhantomData;
@@ -14,7 +14,7 @@ use crate::merkle::MerkleTree;
 #[cfg(test)]
 use crate::store::VecStore;
 #[cfg(test)]
-use crate::test_common::{get_vec_tree_from_slice, Item, XOR128};
+use crate::test_common::{get_vec_tree_from_slice, Item, Sha256Hasher, XOR128};
 
 /// Merkle tree inclusion proof for data element, for which item = Leaf(Hash(Data Item)).
 ///
@@ -235,8 +235,14 @@ impl<T: Eq + Clone + AsRef<[u8]>, BaseTreeArity: Unsigned> Proof<T, BaseTreeArit
 #[cfg(test)]
 // Break one element inside the proof's top layer (if available).
 // Otherwise, break the sub-proof.
-fn modify_proof<BaseTreeArity: Unsigned, SubTreeArity: Unsigned, TopTreeArity: Unsigned>(
-    proof: &mut Proof<Item, BaseTreeArity>,
+fn modify_proof<
+    E: Element,
+    A: Algorithm<E>,
+    BaseTreeArity: Unsigned,
+    SubTreeArity: Unsigned,
+    TopTreeArity: Unsigned,
+>(
+    proof: &mut Proof<E, BaseTreeArity>,
 ) {
     use rand::prelude::*;
 
@@ -252,233 +258,332 @@ fn modify_proof<BaseTreeArity: Unsigned, SubTreeArity: Unsigned, TopTreeArity: U
         assert!(proof.sub_tree_proof.is_some());
     }
 
+    let mut hasher_alg = A::default();
+    let mut tmp = vec![0u8; E::byte_len()];
+
     if TopTreeArity::to_usize() > 0 || SubTreeArity::to_usize() > 0 {
         let i = random::<usize>() % proof.sub_tree_proof.as_ref().unwrap().lemma().len();
         let j = random::<usize>();
 
-        let mut a = XOR128::new();
-        j.hash(&mut a);
+        j.hash(&mut hasher_alg);
 
         // Break random sub-tree proof element
-        proof.sub_tree_proof.as_ref().unwrap().lemma()[i].hash(&mut a);
-        proof.sub_tree_proof.as_mut().unwrap().lemma_mut()[i] = a.hash();
+        proof.sub_tree_proof.as_ref().unwrap().lemma()[i].copy_to_slice(&mut tmp);
+        tmp.hash(&mut hasher_alg);
+        proof.sub_tree_proof.as_mut().unwrap().lemma_mut()[i] = hasher_alg.hash();
     } else {
         let i = random::<usize>() % proof.lemma.len();
         let k = random::<usize>();
 
-        let mut a = XOR128::new();
-        k.hash(&mut a);
+        k.hash(&mut hasher_alg);
 
         // Break random element
-        proof.lemma[i].hash(&mut a);
-        proof.lemma[i] = a.hash();
+        proof.lemma[i].copy_to_slice(&mut tmp);
+        tmp.hash(&mut hasher_alg);
+        proof.lemma[i] = hasher_alg.hash();
     }
 }
 
 #[test]
 fn test_proofs() {
-    let leafs = 32768;
-    let tree = get_vec_tree_from_slice::<Item, XOR128, U2>(leafs);
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 32768;
+        let tree = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        // Break the proof here and assert negative validation.
-        modify_proof::<U2, U0, U0>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            // Break the proof here and assert negative validation.
+            modify_proof::<E, A, BaseTreeArity, SubTreeArity, TopTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
+
+    run_test::<Item, XOR128, U2, U0, U0>();
+    run_test::<Item, Sha256Hasher, U2, U0, U0>();
 }
 
 #[test]
 fn test_compound_quad_broken_proofs() {
-    let leafs = 16384;
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 16384;
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
 
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("Failed to build compound tree");
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("Failed to build compound tree");
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        modify_proof::<U4, U3, U0>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            modify_proof::<E, A, BaseTreeArity, SubTreeArity, TopTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
+    run_test::<Item, XOR128, U4, U3, U0>();
+    run_test::<Item, Sha256Hasher, U4, U3, U0>();
 }
 
 #[test]
 fn test_compound_single_octree_broken_proofs() {
-    let leafs = 32768;
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 32768;
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
 
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U1> =
-        MerkleTree::from_trees(vec![mt1]).expect("Failed to build compound tree");
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1]).expect("Failed to build compound tree");
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        modify_proof::<U8, U1, U0>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            modify_proof::<E, A, BaseTreeArity, SubTreeArity, TopTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
+    run_test::<Item, XOR128, U8, U1, U0>();
+    run_test::<Item, Sha256Hasher, U8, U1, U0>();
 }
 
 #[test]
 #[ignore]
 fn test_compound_octree_broken_proofs() {
-    let leafs = 32768;
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 32768;
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt4 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
 
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4])
+                .expect("Failed to build compound tree");
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        modify_proof::<U8, U4, U0>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            modify_proof::<E, A, BaseTreeArity, SubTreeArity, TopTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
+    run_test::<Item, XOR128, U8, U4, U0>();
+    run_test::<Item, Sha256Hasher, U8, U4, U0>();
 }
 
 #[test]
-fn test_ccompound_quad_broken_proofs() {
-    let leafs = 16384;
+fn test_compound_compound_quad_broken_proofs() {
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 16384;
 
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("failed to build compound merkle tree");
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt1: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3])
+                .expect("failed to build compound merkle tree");
 
-    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt5 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt6 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let cmt2: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
-        MerkleTree::from_trees(vec![mt4, mt5, mt6]).expect("failed to build compound merkle tree");
+        let mt4 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt5 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt6 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt2: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt4, mt5, mt6])
+                .expect("failed to build compound merkle tree");
 
-    let mt7 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt8 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt9 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let cmt3: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
-        MerkleTree::from_trees(vec![mt7, mt8, mt9]).expect("failed to build compound merkle tree");
+        let mt7 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt8 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt9 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt3: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt7, mt8, mt9])
+                .expect("failed to build compound merkle tree");
 
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U4, U3, U3> =
-        MerkleTree::from_sub_trees(vec![cmt1, cmt2, cmt3]).expect("Failed to build ccompound tree");
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity, TopTreeArity> =
+            MerkleTree::from_sub_trees(vec![cmt1, cmt2, cmt3])
+                .expect("Failed to build compound-compound tree");
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        modify_proof::<U4, U3, U3>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            modify_proof::<E, A, BaseTreeArity, SubTreeArity, TopTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
-}
 
-#[test]
-#[ignore]
-fn test_ccompound_single_quad_broken_proofs() {
-    let leafs = 16384;
-
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
-    let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("failed to build compound merkle tree");
-
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U4, U3, U1> =
-        MerkleTree::from_sub_trees(vec![cmt1]).expect("Failed to build ccompound tree");
-
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
-
-        modify_proof::<U4, U1, U3>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
-    }
-}
-
-#[test]
-#[ignore]
-fn test_ccompound_octree_broken_proofs() {
-    let leafs = 32768;
-
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
-
-    let mt5 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt6 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt7 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt8 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt2: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt5, mt6, mt7, mt8]).expect("Failed to build compound tree");
-
-    let mt9 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt10 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt11 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt12 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt3: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt9, mt10, mt11, mt12]).expect("Failed to build compound tree");
-
-    let mt13 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt14 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt15 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt16 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt4: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt13, mt14, mt15, mt16])
-            .expect("Failed to build compound tree");
-
-    let mt17 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt18 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt19 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt20 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt5: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt17, mt18, mt19, mt20])
-            .expect("Failed to build compound tree");
-
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U4, U5> =
-        MerkleTree::from_sub_trees(vec![cmt1, cmt2, cmt3, cmt4, cmt5])
-            .expect("Failed to build ccompound tree");
-
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
-
-        modify_proof::<U8, U5, U4>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
-    }
+    run_test::<Item, XOR128, U4, U3, U3>();
+    run_test::<Item, Sha256Hasher, U4, U3, U3>();
 }
 
 #[test]
 #[ignore]
-fn test_ccompound_single_octree_broken_proofs() {
-    let leafs = 32768;
+fn test_compound_compound_single_quad_broken_proofs() {
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 16384;
 
-    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
-    let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
-        MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt1: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3])
+                .expect("failed to build compound merkle tree");
 
-    let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U4, U1> =
-        MerkleTree::from_sub_trees(vec![cmt1]).expect("Failed to build ccompound tree");
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity, TopTreeArity> =
+            MerkleTree::from_sub_trees(vec![cmt1]).expect("Failed to build compound-compound tree");
 
-    for i in 0..tree.leafs() {
-        let mut p = tree.gen_proof(i).unwrap();
-        assert!(p.validate::<XOR128>().expect("failed to validate"));
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
 
-        modify_proof::<U8, U1, U4>(&mut p);
-        assert!(!p.validate::<XOR128>().expect("failed to validate"));
+            // TODO investigate why SubTree and TopTree are substituted (in origin test)
+            modify_proof::<E, A, BaseTreeArity, TopTreeArity, SubTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
     }
+    run_test::<Item, XOR128, U4, U3, U1>();
+    run_test::<Item, Sha256Hasher, U4, U3, U1>();
+}
+
+#[test]
+#[ignore]
+fn test_compound_compound_octree_broken_proofs() {
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 32768;
+
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt4 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt1: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4])
+                .expect("Failed to build compound tree");
+
+        let mt5 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt6 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt7 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt8 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt2: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt5, mt6, mt7, mt8])
+                .expect("Failed to build compound tree");
+
+        let mt9 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt10 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt11 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt12 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt3: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt9, mt10, mt11, mt12])
+                .expect("Failed to build compound tree");
+
+        let mt13 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt14 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt15 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt16 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt4: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt13, mt14, mt15, mt16])
+                .expect("Failed to build compound tree");
+
+        let mt17 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt18 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt19 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt20 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt5: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt17, mt18, mt19, mt20])
+                .expect("Failed to build compound tree");
+
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity, TopTreeArity> =
+            MerkleTree::from_sub_trees(vec![cmt1, cmt2, cmt3, cmt4, cmt5])
+                .expect("Failed to build compound-compound tree");
+
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
+
+            // TODO investigate why SubTree and TopTree are substituted (in origin test)
+            modify_proof::<E, A, BaseTreeArity, TopTreeArity, SubTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
+    }
+    run_test::<Item, XOR128, U8, U4, U5>();
+    run_test::<Item, Sha256Hasher, U8, U4, U5>();
+}
+
+#[test]
+#[ignore]
+fn test_compound_compound_single_octree_broken_proofs() {
+    fn run_test<
+        E: Element,
+        A: Algorithm<E>,
+        BaseTreeArity: Unsigned,
+        SubTreeArity: Unsigned,
+        TopTreeArity: Unsigned,
+    >() {
+        let leafs = 32768;
+
+        let mt1 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt2 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt3 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let mt4 = get_vec_tree_from_slice::<E, A, BaseTreeArity>(leafs);
+        let cmt1: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity> =
+            MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4])
+                .expect("Failed to build compound tree");
+
+        let tree: MerkleTree<E, A, VecStore<E>, BaseTreeArity, SubTreeArity, TopTreeArity> =
+            MerkleTree::from_sub_trees(vec![cmt1]).expect("Failed to build ccompound tree");
+
+        for i in 0..tree.leafs() {
+            let mut p = tree.gen_proof(i).unwrap();
+            assert!(p.validate::<A>().expect("failed to validate"));
+
+            // TODO investigate why SubTree and TopTree are substituted (in origin test)
+            modify_proof::<E, A, BaseTreeArity, TopTreeArity, SubTreeArity>(&mut p);
+            assert!(!p.validate::<A>().expect("failed to validate"));
+        }
+    }
+
+    run_test::<Item, XOR128, U8, U4, U1>();
+    run_test::<Item, Sha256Hasher, U8, U4, U1>();
 }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -278,7 +278,7 @@ fn modify_proof<BaseTreeArity: Unsigned, SubTreeArity: Unsigned, TopTreeArity: U
 #[test]
 fn test_proofs() {
     let leafs = 32768;
-    let tree = get_vec_tree_from_slice::<U2>(leafs);
+    let tree = get_vec_tree_from_slice::<Item, XOR128, U2>(leafs);
 
     for i in 0..tree.leafs() {
         let mut p = tree.gen_proof(i).unwrap();
@@ -293,9 +293,9 @@ fn test_proofs() {
 #[test]
 fn test_compound_quad_broken_proofs() {
     let leafs = 16384;
-    let mt1 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
 
     let tree: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("Failed to build compound tree");
@@ -312,7 +312,7 @@ fn test_compound_quad_broken_proofs() {
 #[test]
 fn test_compound_single_octree_broken_proofs() {
     let leafs = 32768;
-    let mt1 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
 
     let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U1> =
         MerkleTree::from_trees(vec![mt1]).expect("Failed to build compound tree");
@@ -330,10 +330,10 @@ fn test_compound_single_octree_broken_proofs() {
 #[ignore]
 fn test_compound_octree_broken_proofs() {
     let leafs = 32768;
-    let mt1 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
 
     let tree: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
@@ -351,21 +351,21 @@ fn test_compound_octree_broken_proofs() {
 fn test_ccompound_quad_broken_proofs() {
     let leafs = 16384;
 
-    let mt1 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
     let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("failed to build compound merkle tree");
 
-    let mt4 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt5 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt6 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt5 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt6 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
     let cmt2: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
         MerkleTree::from_trees(vec![mt4, mt5, mt6]).expect("failed to build compound merkle tree");
 
-    let mt7 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt8 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt9 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt7 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt8 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt9 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
     let cmt3: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
         MerkleTree::from_trees(vec![mt7, mt8, mt9]).expect("failed to build compound merkle tree");
 
@@ -386,9 +386,9 @@ fn test_ccompound_quad_broken_proofs() {
 fn test_ccompound_single_quad_broken_proofs() {
     let leafs = 16384;
 
-    let mt1 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U4>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U4>(leafs);
     let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3]).expect("failed to build compound merkle tree");
 
@@ -409,39 +409,39 @@ fn test_ccompound_single_quad_broken_proofs() {
 fn test_ccompound_octree_broken_proofs() {
     let leafs = 32768;
 
-    let mt1 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
 
-    let mt5 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt6 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt7 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt8 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt5 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt6 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt7 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt8 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt2: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt5, mt6, mt7, mt8]).expect("Failed to build compound tree");
 
-    let mt9 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt10 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt11 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt12 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt9 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt10 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt11 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt12 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt3: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt9, mt10, mt11, mt12]).expect("Failed to build compound tree");
 
-    let mt13 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt14 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt15 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt16 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt13 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt14 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt15 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt16 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt4: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt13, mt14, mt15, mt16])
             .expect("Failed to build compound tree");
 
-    let mt17 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt18 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt19 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt20 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt17 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt18 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt19 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt20 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt5: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt17, mt18, mt19, mt20])
             .expect("Failed to build compound tree");
@@ -464,10 +464,10 @@ fn test_ccompound_octree_broken_proofs() {
 fn test_ccompound_single_octree_broken_proofs() {
     let leafs = 32768;
 
-    let mt1 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt2 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt3 = get_vec_tree_from_slice::<U8>(leafs);
-    let mt4 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt1 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt2 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt3 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
+    let mt4 = get_vec_tree_from_slice::<Item, XOR128, U8>(leafs);
     let cmt1: MerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
         MerkleTree::from_trees(vec![mt1, mt2, mt3, mt4]).expect("Failed to build compound tree");
 

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -43,7 +43,9 @@ impl Hasher for XOR128 {
     }
 
     fn finish(&self) -> u64 {
-        unimplemented!()
+        unimplemented!(
+            "Hasher's contract (finish function is not used) is deliberately broken by design"
+        )
     }
 }
 
@@ -107,7 +109,9 @@ impl Default for Sha256Hasher {
 impl Hasher for Sha256Hasher {
     // FIXME: contract is broken by design
     fn finish(&self) -> u64 {
-        unimplemented!()
+        unimplemented!(
+            "Hasher's contract (finish function is not used) is deliberately broken by design"
+        )
     }
 
     fn write(&mut self, bytes: &[u8]) {

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 use crate::hash::Algorithm;
 use crate::merkle::{Element, MerkleTree};
 use crate::store::VecStore;

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -59,22 +59,6 @@ impl Algorithm<Item> for XOR128 {
     }
 }
 
-impl fmt::UpperHex for XOR128 {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        if f.alternate() {
-            if let Err(e) = f.write_str("0x") {
-                return Err(e);
-            }
-        }
-        for b in self.data.as_ref() {
-            if let Err(e) = write!(f, "{:02X}", b) {
-                return Err(e);
-            }
-        }
-        Ok(())
-    }
-}
-
 impl Element for [u8; 16] {
     fn byte_len() -> usize {
         16

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -95,8 +95,8 @@ impl Sha256Hasher {
 }
 
 impl Debug for Sha256Hasher {
-    fn fmt(&self, _f: &mut Formatter<'_>) -> fmt::Result {
-        todo!()
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        f.write_str("Sha256Hasher")
     }
 }
 

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -131,9 +131,9 @@ impl Algorithm<Item> for Sha256Hasher {
     }
 }
 
-pub fn get_vec_tree_from_slice<U: Unsigned>(
+pub fn get_vec_tree_from_slice<E: Element, A: Algorithm<E>, U: Unsigned>(
     leafs: usize,
-) -> MerkleTree<Item, XOR128, VecStore<Item>, U> {
+) -> MerkleTree<E, A, VecStore<E>, U> {
     let mut x = Vec::with_capacity(leafs);
     for i in 0..leafs {
         x.push(i * 93);

--- a/src/test_xor128.rs
+++ b/src/test_xor128.rs
@@ -1,4 +1,5 @@
-#[cfg(test)]
+#![cfg(test)]
+
 use crate::hash::{Algorithm, Hashable};
 use crate::merkle::{
     get_merkle_tree_len, get_merkle_tree_row_count, is_merkle_tree_size_valid, Element,


### PR DESCRIPTION
This is a very first PR from my side. It has following goals:
- to get taste of actual communication/collaboration with the team;
- get deeper understanding of the merkletree codebase including small details;
- start unit-testing of SHA256 based Merkle Tree that is used in Filecoin 32Gb sectors (in production).

Here I added new hasher based on SHA-256 additionally to the existing XOR128. I re-used unit tests (by making them generic) specified mostly in test_xor128.rs source file which seems to be the main point of testing. For simplicity I used only trees with `VecStore` storage layer and extending tests to other storages is left for future work.