### PR TITLE
Modernize & Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ positioned-io = "0.2"
 log = "0.4.7"
 serde = { version = "1.0", features = ["derive"]}
 anyhow = "1.0.23"
-typenum = "1.11.2"
 
 [dev-dependencies]
 byteorder = "1.3.1"

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use anyhow::{Context, Result};
@@ -209,7 +209,7 @@ impl<
     MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity, TopTreeArity>
 {
     /// Given a pathbuf, instantiate an ExternalReader and set it for the LevelCacheStore.
-    pub fn set_external_reader_path(&mut self, path: &PathBuf) -> Result<()> {
+    pub fn set_external_reader_path(&mut self, path: &Path) -> Result<()> {
         ensure!(self.data.store_mut().is_some(), "store data required");
 
         self.data
@@ -445,7 +445,7 @@ impl<
             is_merkle_tree_size_valid(leafs, branches),
             "MerkleTree size is invalid given the arity"
         );
-        let store = S::new_from_slice(tree_len, &data).context("failed to create data store")?;
+        let store = S::new_from_slice(tree_len, data).context("failed to create data store")?;
         let root = store.read_at(store.len() - 1)?;
 
         Ok(MerkleTree {
@@ -490,7 +490,7 @@ impl<
             "MerkleTree size is invalid given the arity"
         );
 
-        let store = S::new_from_slice_with_config(tree_len, branches, &data, config)
+        let store = S::new_from_slice_with_config(tree_len, branches, data, config)
             .context("failed to create data store")?;
         let root = store.read_at(store.len() - 1)?;
 
@@ -522,11 +522,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 
@@ -587,11 +587,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 
@@ -646,11 +646,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 

--- a/src/store/disk.rs
+++ b/src/store/disk.rs
@@ -375,7 +375,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
                 let hashed_nodes_as_bytes = chunk_nodes.chunks(branches).fold(
                     Vec::with_capacity(nodes_size),
                     |mut acc, nodes| {
-                        let h = A::default().multi_node(&nodes, level);
+                        let h = A::default().multi_node(nodes, level);
                         acc.extend_from_slice(h.as_ref());
                         acc
                     },

--- a/src/store/level_cache.rs
+++ b/src/store/level_cache.rs
@@ -464,7 +464,7 @@ impl<E: Element, R: Read + Send + Sync> Store<E> for LevelCacheStore<E, R> {
                 let hashed_nodes_as_bytes = chunk_nodes.chunks(branches).fold(
                     Vec::with_capacity(nodes_size),
                     |mut acc, nodes| {
-                        let h = A::default().multi_node(&nodes, level);
+                        let h = A::default().multi_node(nodes, level);
                         acc.extend_from_slice(h.as_ref());
                         acc
                     },

--- a/src/store/vec.rs
+++ b/src/store/vec.rs
@@ -64,7 +64,7 @@ impl<E: Element> Store<E> for VecStore<E> {
         data: &[u8],
         _config: StoreConfig,
     ) -> Result<Self> {
-        Self::new_from_slice(size, &data)
+        Self::new_from_slice(size, data)
     }
 
     fn new_from_slice(size: usize, data: &[u8]) -> Result<Self> {

--- a/src/test_cmh.rs
+++ b/src/test_cmh.rs
@@ -10,6 +10,7 @@ use crate::test_item::Item;
 
 /// Custom merkle hash util test
 #[derive(Debug, Clone, Default)]
+#[allow(clippy::upper_case_acronyms)]
 struct CMH(DefaultHasher);
 
 impl CMH {

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -134,7 +134,7 @@ impl Algorithm<Item> for Sha256Hasher {
         if item_size < hash_output.len() {
             result.copy_from_slice(&hash_output.as_slice()[0..item_size]);
         } else {
-            result.copy_from_slice(&hash_output.as_slice())
+            result.copy_from_slice(hash_output.as_slice())
         }
         result
     }

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -7,7 +7,6 @@ use std::hash::Hasher;
 
 use crypto::digest::Digest;
 use crypto::sha2::Sha256;
-use typenum::marker_traits::Unsigned;
 
 use crate::hash::Algorithm;
 use crate::merkle::{Element, MerkleTree};
@@ -140,9 +139,9 @@ impl Algorithm<Item> for Sha256Hasher {
     }
 }
 
-pub fn get_vec_tree_from_slice<E: Element, A: Algorithm<E>, U: Unsigned>(
+pub fn get_vec_tree_from_slice<E: Element, A: Algorithm<E>, const BRANCHES: usize>(
     leafs: usize,
-) -> MerkleTree<E, A, VecStore<E>, U> {
+) -> MerkleTree<E, A, VecStore<E>, BRANCHES> {
     let mut x = Vec::with_capacity(leafs);
     for i in 0..leafs {
         x.push(i * 93);

--- a/src/test_item.rs
+++ b/src/test_item.rs
@@ -44,9 +44,9 @@ impl From<u64> for Item {
     }
 }
 
-impl Into<u64> for Item {
-    fn into(self) -> u64 {
-        self.0
+impl From<Item> for u64 {
+    fn from(x: Item) -> u64 {
+        x.0
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -114,7 +114,7 @@ impl Default for TestXOR128 {
 
 impl Algorithm<TestItem> for TestXOR128 {
     fn hash(&mut self) -> TestItem {
-        self.data.clone()
+        self.data
     }
 }
 
@@ -168,7 +168,7 @@ impl Algorithm<TestItem> for TestSha256Hasher {
                 .0
                 .copy_from_slice(&hash_output.as_slice()[0..item_size]);
         } else {
-            result.0.copy_from_slice(&hash_output.as_slice())
+            result.0.copy_from_slice(hash_output.as_slice())
         }
         result
     }
@@ -211,11 +211,10 @@ pub fn generate_byte_slice_tree<E: Element, A: Algorithm<E>>(leaves: usize) -> V
             a.hash()
         })
         .take(leaves)
-        .map(|item| {
+        .flat_map(|item| {
             a2.reset();
             a2.leaf(item).as_ref().to_vec()
         })
-        .flatten()
         .collect();
 
     dataset

--- a/tests/test_arities.rs
+++ b/tests/test_arities.rs
@@ -130,7 +130,7 @@ fn test_compound_compound_tree_arities() {
             .unwrap();
 
         let base_trees = (0..TopTreeArity::to_usize())
-            .map(|_| {
+            .flat_map(|_| {
                 get_vector_of_base_trees::<
                     TestItemType,
                     TestSha256Hasher,
@@ -139,7 +139,6 @@ fn test_compound_compound_tree_arities() {
                     SubTreeArity,
                 >(leaves)
             })
-            .flatten()
             .collect::<Vec<MerkleTree<_, _, _, BaseTreeArity>>>();
 
         let tree = MerkleTree::from_sub_trees_as_trees(base_trees).expect(

--- a/tests/test_arities.rs
+++ b/tests/test_arities.rs
@@ -1,8 +1,6 @@
 #![cfg(not(tarpaulin_include))]
 pub mod common;
 
-use typenum::{Unsigned, U0, U2, U3, U4, U5, U8};
-
 use merkletree::merkle::{get_merkle_tree_len_generic, Element, MerkleTree};
 use merkletree::store::VecStore;
 
@@ -13,63 +11,64 @@ use crate::common::{
 
 #[test]
 fn test_base_tree_arities() {
-    fn run_test<BaseTreeArity: Unsigned>(leaves: usize, root: TestItemType) {
+    fn run_test<const BASE_TREE_ARITY: usize>(leaves: usize, root: TestItemType) {
         let expected_leaves = leaves;
-        let len = get_merkle_tree_len_generic::<BaseTreeArity, U0, U0>(leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<BASE_TREE_ARITY, 0, 0>(leaves).unwrap();
 
         let tree = instantiate_new::<
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
+            BASE_TREE_ARITY,
         >(leaves, None);
         test_disk_mmap_vec_tree_functionality::<
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
-            U0,
-            U0,
+            BASE_TREE_ARITY,
+            0,
+            0,
         >(tree, expected_leaves, len, root);
     }
 
     let root = TestItemType::from_slice(&[
         142, 226, 200, 91, 184, 251, 142, 223, 219, 43, 122, 241, 23, 37, 97, 46,
     ]);
-    run_test::<U2>(4, root);
+    run_test::<2>(4, root);
 
     let root = TestItemType::from_slice(&[
         128, 59, 187, 58, 199, 144, 7, 238, 128, 146, 124, 33, 241, 16, 92, 221,
     ]);
-    run_test::<U4>(16, root);
+    run_test::<4>(16, root);
 
     let root = TestItemType::from_slice(&[
         252, 61, 163, 229, 140, 223, 198, 165, 200, 137, 59, 43, 83, 136, 197, 63,
     ]);
-    run_test::<U8>(64, root);
+    run_test::<8>(64, root);
 }
 
 #[test]
 fn test_compound_tree_arities() {
-    fn run_test<BaseTreeArity: Unsigned, SubTreeArity: Unsigned>(
+    fn run_test<const BASE_TREE_ARITY: usize, const SUB_TREE_ARITY: usize>(
         leaves: usize,
         root: TestItemType,
     ) {
-        let expected_leaves = leaves * SubTreeArity::to_usize();
-        let len = get_merkle_tree_len_generic::<BaseTreeArity, SubTreeArity, U0>(leaves).unwrap();
+        let expected_leaves = leaves * SUB_TREE_ARITY;
+        let len =
+            get_merkle_tree_len_generic::<BASE_TREE_ARITY, SUB_TREE_ARITY, 0>(leaves).unwrap();
 
         let tree = MerkleTree::<
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
-            SubTreeArity,
+            BASE_TREE_ARITY,
+            SUB_TREE_ARITY,
         >::from_trees(get_vector_of_base_trees::<
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
-            SubTreeArity,
+            BASE_TREE_ARITY,
+            SUB_TREE_ARITY,
         >(leaves))
         .expect("can't instantiate compound tree [test_compound_tree_arities]");
 
@@ -77,69 +76,74 @@ fn test_compound_tree_arities() {
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
-            SubTreeArity,
-            U0,
+            BASE_TREE_ARITY,
+            SUB_TREE_ARITY,
+            0,
         >(tree, expected_leaves, len, root);
     }
 
     let root = TestItemType::from_slice(&[
         57, 201, 227, 235, 242, 179, 108, 46, 157, 200, 126, 217, 134, 232, 141, 223,
     ]);
-    run_test::<U2, U2>(4, root);
+    run_test::<2, 2>(4, root);
 
     let root = TestItemType::from_slice(&[
         146, 59, 189, 83, 119, 102, 147, 207, 178, 121, 11, 190, 241, 152, 67, 0,
     ]);
-    run_test::<U4, U4>(16, root);
+    run_test::<4, 4>(16, root);
 
     let root = TestItemType::from_slice(&[
         32, 129, 168, 134, 58, 233, 155, 225, 88, 230, 247, 63, 18, 38, 194, 230,
     ]);
-    run_test::<U8, U8>(64, root);
+    run_test::<8, 8>(64, root);
 
     let root = TestItemType::from_slice(&[
         81, 96, 135, 96, 165, 113, 149, 203, 222, 86, 102, 127, 139, 194, 78, 22,
     ]);
-    run_test::<U2, U4>(4, root);
+    run_test::<2, 4>(4, root);
 
     let root = TestItemType::from_slice(&[
         149, 57, 53, 8, 68, 184, 94, 209, 244, 218, 43, 172, 185, 215, 193, 99,
     ]);
-    run_test::<U8, U4>(64, root);
+    run_test::<8, 4>(64, root);
 
     let root = TestItemType::from_slice(&[
         127, 19, 226, 22, 109, 131, 88, 30, 221, 228, 251, 183, 147, 248, 2, 186,
     ]);
-    run_test::<U2, U5>(4, root);
+    run_test::<2, 5>(4, root);
 
     let root = TestItemType::from_slice(&[
         67, 94, 188, 238, 85, 194, 96, 252, 163, 54, 119, 99, 218, 210, 231, 190,
     ]);
-    run_test::<U4, U3>(16, root);
+    run_test::<4, 3>(16, root);
 }
 
 #[test]
 fn test_compound_compound_tree_arities() {
-    fn run_test<BaseTreeArity: Unsigned, SubTreeArity: Unsigned, TopTreeArity: Unsigned>(
+    fn run_test<
+        const BASE_TREE_ARITY: usize,
+        const SUB_TREE_ARITY: usize,
+        const TOP_TREE_ARITY: usize,
+    >(
         leaves: usize,
         root: TestItemType,
     ) {
-        let expected_leaves = leaves * SubTreeArity::to_usize() * TopTreeArity::to_usize();
-        let len = get_merkle_tree_len_generic::<BaseTreeArity, SubTreeArity, TopTreeArity>(leaves)
-            .unwrap();
+        let expected_leaves = leaves * SUB_TREE_ARITY * TOP_TREE_ARITY;
+        let len =
+            get_merkle_tree_len_generic::<BASE_TREE_ARITY, SUB_TREE_ARITY, TOP_TREE_ARITY>(leaves)
+                .unwrap();
 
-        let base_trees = (0..TopTreeArity::to_usize())
+        let base_trees = (0..TOP_TREE_ARITY)
             .flat_map(|_| {
                 get_vector_of_base_trees::<
                     TestItemType,
                     TestSha256Hasher,
                     VecStore<TestItemType>,
-                    BaseTreeArity,
-                    SubTreeArity,
+                    BASE_TREE_ARITY,
+                    SUB_TREE_ARITY,
                 >(leaves)
             })
-            .collect::<Vec<MerkleTree<_, _, _, BaseTreeArity>>>();
+            .collect::<Vec<MerkleTree<_, _, _, BASE_TREE_ARITY>>>();
 
         let tree = MerkleTree::from_sub_trees_as_trees(base_trees).expect(
             "can't instantiate compound-compound tree [test_compound_compound_tree_arities]",
@@ -149,28 +153,28 @@ fn test_compound_compound_tree_arities() {
             TestItemType,
             TestSha256Hasher,
             VecStore<TestItemType>,
-            BaseTreeArity,
-            SubTreeArity,
-            TopTreeArity,
+            BASE_TREE_ARITY,
+            SUB_TREE_ARITY,
+            TOP_TREE_ARITY,
         >(tree, expected_leaves, len, root);
     }
 
     let root = TestItemType::from_slice(&[
         77, 96, 160, 26, 181, 161, 25, 63, 24, 181, 60, 43, 45, 20, 246, 181,
     ]);
-    run_test::<U2, U2, U2>(4, root);
+    run_test::<2, 2, 2>(4, root);
 
     let root = TestItemType::from_slice(&[
         52, 152, 123, 224, 174, 42, 152, 12, 199, 4, 105, 245, 176, 59, 230, 86,
     ]);
-    run_test::<U8, U8, U2>(64, root);
+    run_test::<8, 8, 2>(64, root);
 
     // TODO investigate whether limitations of 'from_sub_trees_as_trees' constructors are reasonable
-    // run_test::<U2, U4, U8>(4, root);
-    // run_test::<U2, U2, U4>(4, root);
-    // run_test::<U8, U2, U8>(64, root);
-    // run_test::<U8, U8, U8>(64, root);
-    // run_test::<U8, U8, U3>(64, root);
-    // run_test::<U2, U5, U3>(4, root);
+    // run_test::<2, 4, 8>(4, root);
+    // run_test::<2, 2, 4>(4, root);
+    // run_test::<8, 2, 8>(64, root);
+    // run_test::<8, 8, 8>(64, root);
+    // run_test::<8, 8, 3>(64, root);
+    // run_test::<2, 5, 3>(4, root);
     // etc...
 }

--- a/tests/test_base_constructors.rs
+++ b/tests/test_base_constructors.rs
@@ -2,7 +2,6 @@
 pub mod common;
 
 use rayon::iter::IntoParallelIterator;
-use typenum::{Unsigned, U0, U2, U8};
 
 use merkletree::hash::Algorithm;
 use merkletree::merkle::{
@@ -19,28 +18,33 @@ use crate::common::{
 };
 
 /// Base tree constructors
-fn instantiate_try_from_iter<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_try_from_iter<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_vector_of_elements::<E>(leaves);
     MerkleTree::try_from_iter(dataset.into_iter().map(Ok))
         .expect("failed to instantiate tree [try_from_iter]")
 }
 
-fn instantiate_from_par_iter<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_par_iter<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_vector_of_elements::<E>(leaves);
     MerkleTree::from_par_iter(dataset.into_par_iter())
         .expect("failed to instantiate tree [try_from_par_iter]")
 }
 
-fn instantiate_try_from_iter_with_config<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_try_from_iter_with_config<
+    E: Element,
+    A: Algorithm<E>,
+    S: Store<E>,
+    const BRANCHES: usize,
+>(
     leaves: usize,
     config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_vector_of_elements::<E>(leaves);
     MerkleTree::try_from_iter_with_config(
         dataset.into_iter().map(Ok),
@@ -49,10 +53,15 @@ fn instantiate_try_from_iter_with_config<E: Element, A: Algorithm<E>, S: Store<E
     .expect("failed to instantiate tree [try_from_iter_with_config]")
 }
 
-fn instantiate_from_par_iter_with_config<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_par_iter_with_config<
+    E: Element,
+    A: Algorithm<E>,
+    S: Store<E>,
+    const BRANCHES: usize,
+>(
     leaves: usize,
     config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_vector_of_elements::<E>(leaves);
     MerkleTree::from_par_iter_with_config(
         dataset,
@@ -61,18 +70,23 @@ fn instantiate_from_par_iter_with_config<E: Element, A: Algorithm<E>, S: Store<E
     .expect("failed to instantiate tree [from_par_iter_with_config]")
 }
 
-fn instantiate_from_data<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_data<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = generate_vector_of_usizes(leaves);
     MerkleTree::from_data(dataset.as_slice()).expect("failed to instantiate tree [from_data]")
 }
 
-fn instantiate_from_data_with_config<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_data_with_config<
+    E: Element,
+    A: Algorithm<E>,
+    S: Store<E>,
+    const BRANCHES: usize,
+>(
     leaves: usize,
     config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = generate_vector_of_usizes(leaves);
     MerkleTree::from_data_with_config(
         dataset.as_slice(),
@@ -81,11 +95,11 @@ fn instantiate_from_data_with_config<E: Element, A: Algorithm<E>, S: Store<E>, U
     .expect("failed to instantiate tree [from_data_with_config]")
 }
 
-fn instantiate_from_data_store<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_data_store<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
-    let tree = instantiate_from_data::<E, A, S, U>(leaves, None);
+) -> MerkleTree<E, A, S, BRANCHES> {
+    let tree = instantiate_from_data::<E, A, S, BRANCHES>(leaves, None);
     let serialized_tree = common::serialize_tree(tree);
     let store = Store::new_from_slice(serialized_tree.len(), &serialized_tree)
         .expect("can't create new store over existing one [from_data_store]");
@@ -93,20 +107,20 @@ fn instantiate_from_data_store<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsi
         .expect("failed to instantiate tree [from_data_store]")
 }
 
-fn instantiate_from_tree_slice<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_tree_slice<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
-    let tree = instantiate_from_data::<E, A, S, U>(leaves, None);
+) -> MerkleTree<E, A, S, BRANCHES> {
+    let tree = instantiate_from_data::<E, A, S, BRANCHES>(leaves, None);
     let serialized_tree = common::serialize_tree(tree);
     MerkleTree::from_tree_slice(serialized_tree.as_slice(), leaves)
         .expect("failed to instantiate tree [from_tree_slice]")
 }
 
-fn instantiate_from_byte_slice<E: Element, A: Algorithm<E>, S: Store<E>, U: Unsigned>(
+fn instantiate_from_byte_slice<E: Element, A: Algorithm<E>, S: Store<E>, const BRANCHES: usize>(
     leaves: usize,
     _config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_byte_slice_tree::<E, A>(leaves);
     MerkleTree::from_byte_slice(dataset.as_slice())
         .expect("failed to instantiate tree [from_byte_slice]")
@@ -116,11 +130,11 @@ fn instantiate_from_byte_slice_with_config<
     E: Element,
     A: Algorithm<E>,
     S: Store<E>,
-    U: Unsigned,
+    const BRANCHES: usize,
 >(
     leaves: usize,
     config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
+) -> MerkleTree<E, A, S, BRANCHES> {
     let dataset = common::generate_byte_slice_tree::<E, A>(leaves);
     MerkleTree::from_byte_slice_with_config(
         dataset.as_slice(),
@@ -133,12 +147,12 @@ fn instantiate_from_tree_slice_with_config<
     E: Element,
     A: Algorithm<E>,
     S: Store<E>,
-    U: Unsigned,
+    const BRANCHES: usize,
 >(
     leaves: usize,
     config: Option<StoreConfig>,
-) -> MerkleTree<E, A, S, U> {
-    let tmp_tree = instantiate_from_data::<E, A, S, U>(leaves, None);
+) -> MerkleTree<E, A, S, BRANCHES> {
+    let tmp_tree = instantiate_from_data::<E, A, S, BRANCHES>(leaves, None);
     let serialized_tree = common::serialize_tree(tmp_tree);
     MerkleTree::from_tree_slice_with_config(
         serialized_tree.as_slice(),
@@ -149,23 +163,23 @@ fn instantiate_from_tree_slice_with_config<
 }
 
 /// Test executor
-fn run_test_base_tree<E: Element, A: Algorithm<E>, S: Store<E>, BaseTreeArity: Unsigned>(
-    constructor: fn(usize, Option<StoreConfig>) -> MerkleTree<E, A, S, BaseTreeArity>,
+fn run_test_base_tree<E: Element, A: Algorithm<E>, S: Store<E>, const BASE_TREE_ARITY: usize>(
+    constructor: fn(usize, Option<StoreConfig>) -> MerkleTree<E, A, S, BASE_TREE_ARITY>,
     leaves_in_tree: usize,
     config: Option<StoreConfig>,
     expected_leaves: usize,
     expected_len: usize,
     expected_root: E,
 ) {
-    // base tree has SubTreeArity and TopTreeArity parameters equal to zero
-    let tree: MerkleTree<E, A, S, BaseTreeArity, U0, U0> = constructor(leaves_in_tree, config);
+    // base tree has SUB_TREE_ARITY and TOP_TREE_ARITY parameters equal to zero
+    let tree: MerkleTree<E, A, S, BASE_TREE_ARITY, 0, 0> = constructor(leaves_in_tree, config);
     test_disk_mmap_vec_tree_functionality(tree, expected_leaves, expected_len, expected_root);
 }
 
 /// Ultimately we have a list of constructors for base trees
 /// that we can divide by actual dataset generator and organize
 /// complex integration tests that evaluate correct instantiation
-/// of base tree (with fixing base tree arity parameter to U8 - oct tree)
+/// of base tree (with fixing base tree arity parameter to 8 - oct tree)
 /// using distinct hashers
 ///
 /// [Iterable]
@@ -190,9 +204,9 @@ fn test_iterable() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>, S: Store<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves;
-        let len = get_merkle_tree_len_generic::<U8, U0, U0>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 0, 0>(base_tree_leaves).unwrap();
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_new,
             base_tree_leaves,
             None,
@@ -201,7 +215,7 @@ fn test_iterable() {
             root,
         );
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_try_from_iter,
             base_tree_leaves,
             None,
@@ -210,7 +224,7 @@ fn test_iterable() {
             root,
         );
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_par_iter,
             base_tree_leaves,
             None,
@@ -221,7 +235,7 @@ fn test_iterable() {
 
         let distinguisher = "instantiate_new_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_new_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -236,7 +250,7 @@ fn test_iterable() {
 
         let distinguisher = "instantiate_try_from_iter_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_try_from_iter_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -251,7 +265,7 @@ fn test_iterable() {
 
         let distinguisher = "instantiate_from_par_iter_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_par_iter_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -286,9 +300,9 @@ fn test_iterable_hashable_and_serialization() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>, S: Store<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves;
-        let len = get_merkle_tree_len_generic::<U8, U0, U0>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 0, 0>(base_tree_leaves).unwrap();
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_data,
             base_tree_leaves,
             None,
@@ -299,7 +313,7 @@ fn test_iterable_hashable_and_serialization() {
 
         let distinguisher = "instantiate_from_data_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_data_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -312,7 +326,7 @@ fn test_iterable_hashable_and_serialization() {
             root,
         );
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_data_store,
             base_tree_leaves,
             None,
@@ -321,7 +335,7 @@ fn test_iterable_hashable_and_serialization() {
             root,
         );
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_tree_slice,
             base_tree_leaves,
             None,
@@ -330,7 +344,7 @@ fn test_iterable_hashable_and_serialization() {
             root,
         );
 
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_byte_slice,
             base_tree_leaves,
             None,
@@ -341,7 +355,7 @@ fn test_iterable_hashable_and_serialization() {
 
         let distinguisher = "instantiate_from_byte_slice_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_byte_slice_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -356,7 +370,7 @@ fn test_iterable_hashable_and_serialization() {
 
         let distinguisher = "instantiate_from_tree_slice_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_tree::<E, A, S, U8>(
+        run_test_base_tree::<E, A, S, 8>(
             instantiate_from_tree_slice_with_config,
             base_tree_leaves,
             Some(StoreConfig::new(
@@ -391,8 +405,13 @@ fn test_iterable_hashable_and_serialization() {
 /// Since Rust doesn't provide special tools for comparing types (only some unstable tools
 /// exist - https://stackoverflow.com/questions/60138397/how-to-test-for-type-equality-in-rust)
 /// we just compare partial strings from formatted storages
-fn run_base_tree_storage_test<E: Element, A: Algorithm<E>, S: Store<E>, BaseTreeArity: Unsigned>(
-    constructor: fn(usize, Option<StoreConfig>) -> MerkleTree<E, A, S, BaseTreeArity>,
+fn run_base_tree_storage_test<
+    E: Element,
+    A: Algorithm<E>,
+    S: Store<E>,
+    const BASE_TREE_ARITY: usize,
+>(
+    constructor: fn(usize, Option<StoreConfig>) -> MerkleTree<E, A, S, BASE_TREE_ARITY>,
     leaves_in_tree: usize,
     config: Option<StoreConfig>,
     expected_storage: S,
@@ -426,7 +445,7 @@ fn test_storage_types() {
     type DiskStorage = DiskStore<TestItemType>;
     let distinguisher = "instantiate_new_with_config-disk";
     let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-    run_base_tree_storage_test::<TestItemType, TestXOR128, DiskStorage, U8>(
+    run_base_tree_storage_test::<TestItemType, TestXOR128, DiskStorage, 8>(
         instantiate_new_with_config,
         base_tree_leaves,
         Some(StoreConfig::new(
@@ -441,7 +460,7 @@ fn test_storage_types() {
     type MmapStorage = MmapStore<TestItemType>;
     let distinguisher = "instantiate_new_with_config-mmap";
     let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-    run_base_tree_storage_test::<TestItemType, TestXOR128, MmapStorage, U8>(
+    run_base_tree_storage_test::<TestItemType, TestXOR128, MmapStorage, 8>(
         instantiate_new_with_config,
         base_tree_leaves,
         Some(StoreConfig::new(
@@ -456,7 +475,7 @@ fn test_storage_types() {
     type LevelCacheStorage = LevelCacheStore<TestItemType, std::fs::File>;
     let distinguisher = "instantiate_new_with_config-level-cache";
     let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-    run_base_tree_storage_test::<TestItemType, TestXOR128, LevelCacheStorage, U8>(
+    run_base_tree_storage_test::<TestItemType, TestXOR128, LevelCacheStorage, 8>(
         instantiate_new_with_config,
         base_tree_leaves,
         Some(StoreConfig::new(
@@ -472,14 +491,14 @@ fn test_storage_types() {
 #[test]
 #[ignore]
 fn test_large_base_trees() {
-    fn run_test<BaseTreeArity: Unsigned>(
+    fn run_test<const BASE_TREE_ARITY: usize>(
         leaves: usize,
         len: usize,
         row_count: usize,
         num_challenges: usize,
     ) {
         let big_tree =
-            instantiate_new::<TestItemType, TestXOR128, VecStore<TestItemType>, BaseTreeArity>(
+            instantiate_new::<TestItemType, TestXOR128, VecStore<TestItemType>, BASE_TREE_ARITY>(
                 leaves, None,
             );
 
@@ -497,14 +516,14 @@ fn test_large_base_trees() {
     }
 
     let (leaves, len, row_count, num_challenges) = { (16777216, 19173961, 9, 1024) };
-    run_test::<U8>(leaves, len, row_count, num_challenges);
+    run_test::<8>(leaves, len, row_count, num_challenges);
 
     let leaves = SMALL_TREE_BUILD * 2;
     let num_challenges = SMALL_TREE_BUILD * 2;
     let branches = 2;
-    run_test::<U2>(
+    run_test::<2>(
         leaves,
-        get_merkle_tree_len_generic::<U2, U0, U0>(leaves).expect("can't get tree len"),
+        get_merkle_tree_len_generic::<2, 0, 0>(leaves).expect("can't get tree len"),
         get_merkle_tree_row_count(leaves, branches),
         num_challenges,
     );

--- a/tests/test_compound_compound_constructors.rs
+++ b/tests/test_compound_compound_constructors.rs
@@ -47,12 +47,11 @@ fn instantiate_cctree_from_sub_trees_as_trees<
     base_tree_leaves: usize,
 ) -> MerkleTree<E, A, S, BaseTreeArity, SubTreeArity, TopTreeArity> {
     let base_trees = (0..TopTreeArity::to_usize())
-        .map(|_| {
+        .flat_map(|_| {
             (0..SubTreeArity::to_usize())
                 .map(|_| instantiate_new(base_tree_leaves, None))
                 .collect::<Vec<MerkleTree<E, A, S, BaseTreeArity, U0, U0>>>()
         })
-        .flatten()
         .collect();
 
     MerkleTree::from_sub_trees_as_trees(base_trees)
@@ -78,16 +77,12 @@ fn instantiate_cctree_from_sub_tree_store_configs<
         .expect("can't get tree len [instantiate_cctree_from_sub_tree_store_configs]");
 
     let configs = (0..TopTreeArity::to_usize())
-        .map(|j| {
+        .flat_map(|j| {
             (0..SubTreeArity::to_usize())
                 .map(|i| {
                     let replica = format!(
                         "{}-{}-{}-{}-{}-replica",
-                        distinguisher,
-                        i.to_string(),
-                        j.to_string(),
-                        base_tree_leaves,
-                        len,
+                        distinguisher, i, j, base_tree_leaves, len,
                     );
 
                     // we attempt to discard all intermediate layers, except bottom one (set of leaves) and top-level root of base tree
@@ -101,7 +96,6 @@ fn instantiate_cctree_from_sub_tree_store_configs<
                 })
                 .collect::<Vec<StoreConfig>>()
         })
-        .flatten()
         .collect::<Vec<StoreConfig>>();
 
     MerkleTree::from_sub_tree_store_configs(base_tree_leaves, &configs)

--- a/tests/test_compound_constructors.rs
+++ b/tests/test_compound_constructors.rs
@@ -123,11 +123,7 @@ fn instantiate_ctree_from_store_configs<
         .map(|index| {
             let replica = format!(
                 "{}-{}-{}-{}-{}-replica",
-                distinguisher,
-                index.to_string(),
-                base_tree_leaves,
-                len,
-                row_count,
+                distinguisher, index, base_tree_leaves, len, row_count,
             );
 
             let config = StoreConfig::new(

--- a/tests/test_levelcache_trees.rs
+++ b/tests/test_levelcache_trees.rs
@@ -23,7 +23,7 @@
 /// those items and dumping data to filesystem
 pub mod common;
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use merkletree::hash::Algorithm;
 use merkletree::merkle::{
@@ -41,7 +41,7 @@ use crate::common::{
 /// LevelCacheStore constructors of base trees
 fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -93,7 +93,7 @@ fn lc_instantiate_try_from_iter_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -141,7 +141,7 @@ fn lc_instantiate_from_par_iter_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -185,7 +185,7 @@ fn lc_instantiate_from_par_iter_with_config<
 
 fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_usizes(leaves);
@@ -233,7 +233,7 @@ fn lc_instantiate_from_byte_slice_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_byte_slice_tree::<E, A>(leaves);
@@ -282,7 +282,7 @@ fn lc_instantiate_from_tree_slice_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_usizes(leaves);
@@ -329,14 +329,15 @@ fn lc_instantiate_from_tree_slice_with_config<
 }
 
 /// Test executor
+#[allow(clippy::type_complexity)]
 fn run_test_base_lc_tree<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     constructor: fn(
         usize,
-        &PathBuf,
+        &Path,
         usize,
     ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>,
     leaves_in_tree: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
     expected_leaves: usize,
     expected_len: usize,
@@ -371,7 +372,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_new_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -383,7 +384,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_try_from_iter_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -395,7 +396,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_par_iter_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -426,7 +427,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_data_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -438,7 +439,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_byte_slice_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -451,7 +452,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_tree_slice_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -477,7 +478,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
     SubTreeArity: Unsigned,
 >(
     base_tree_leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity> {
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -496,7 +497,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
             // prepare replica file content
             let config = StoreConfig::new(
                 temp_dir_path,
-                format!("{}{}", String::from("config_id"), index.to_string()),
+                format!("config_id{}", index),
                 rows_to_discard
                     .expect("can't get rows_to_discard [lc_instantiate_ctree_from_store_configs_and_replica]"),
             );
@@ -515,7 +516,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
             // generate valid configs and bind them each to actual data of the tree
             let lc_config = StoreConfig::from_config(
                 &config,
-                format!("{}{}", String::from("lc_config_id"), index.to_string()),
+                format!("lc_config_id{}", index),
                 Some(tree.len()),
             );
             let mut tree = instantiate_new_with_config::<
@@ -554,7 +555,7 @@ fn test_compound_levelcache_trees() {
         let rows_to_discard = 0;
         let tree = lc_instantiate_ctree_from_store_configs_and_replica::<E, A, U8, U8>(
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             Some(rows_to_discard),
         );
 
@@ -585,7 +586,7 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
     TopTreeArity: Unsigned,
 >(
     base_tree_leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity, TopTreeArity>
 {
@@ -601,17 +602,16 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
         .collect();
 
     let configs = (0..TopTreeArity::to_usize())
-        .map(|j| {
+        .flat_map(|j| {
             (0..SubTreeArity::to_usize())
                 .map(|i| {
                     // prepare replica file content
                     let config = StoreConfig::new(
                         temp_dir_path,
                         format!(
-                            "{}{}{}",
-                            String::from("config_id"),
-                            i.to_string(),
-                            j.to_string()
+                            "config_id{}{}",
+                            i,
+                            j
                         ),
                         rows_to_discard.expect(
                             "can't get rows_to_discard [lc_instantiate_cctree_from_sub_tree_store_configs_and_replica]",
@@ -634,10 +634,9 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                     let lc_config = StoreConfig::from_config(
                         &config,
                         format!(
-                            "{}{}{}",
-                            String::from("lc_config_id"),
-                            i.to_string(),
-                            j.to_string()
+                            "lc_config_id{}{}",
+                            i,
+                            j
                         ),
                         Some(tree.len()),
                     );
@@ -654,7 +653,6 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                 })
                 .collect::<Vec<StoreConfig>>()
         })
-        .flatten()
         .collect::<Vec<StoreConfig>>();
 
     MerkleTree::from_sub_tree_store_configs_and_replica(
@@ -681,7 +679,7 @@ fn test_compound_compound_levelcache_trees() {
         let rows_to_discard = 0;
         let tree = lc_instantiate_cctree_from_sub_tree_store_configs_and_replica::<E, A, U8, U8, U2>(
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             Some(rows_to_discard),
         );
 

--- a/tests/test_levelcache_trees.rs
+++ b/tests/test_levelcache_trees.rs
@@ -30,7 +30,6 @@ use merkletree::merkle::{
     get_merkle_tree_len_generic, Element, FromIndexedParallelIterator, MerkleTree,
 };
 use merkletree::store::{DiskStore, LevelCacheStore, ReplicaConfig, StoreConfig, VecStore};
-use typenum::{Unsigned, U0, U2, U8};
 
 use crate::common::{
     dump_tree_data_to_replica, generate_byte_slice_tree, generate_vector_of_elements,
@@ -39,11 +38,11 @@ use crate::common::{
 };
 
 /// LevelCacheStore constructors of base trees
-fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
+fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, const BASE_TREE_ARITY: usize>(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_vector_of_elements::<E>(leaves);
 
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -58,13 +57,13 @@ fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Un
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::new_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::new_with_config(
         dataset.clone(),
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_new_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -78,7 +77,7 @@ fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Un
         Some(tree.len()),
     );
     let mut tree =
-        MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::new_with_config(
+        MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::new_with_config(
             dataset, lc_config,
         )
         .expect("failed to instantiate LC tree [lc_instantiate_new_with_config]");
@@ -90,12 +89,12 @@ fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Un
 fn lc_instantiate_try_from_iter_with_config<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
 >(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_vector_of_elements::<E>(leaves);
 
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -110,13 +109,13 @@ fn lc_instantiate_try_from_iter_with_config<
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::try_from_iter_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::try_from_iter_with_config(
         dataset.clone().into_iter().map(Ok),
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_try_from_iter_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -129,7 +128,7 @@ fn lc_instantiate_try_from_iter_with_config<
         format!("{}-{}", "lc_instantiate_try_from_iter_with_config", "lc"),
         Some(tree.len()),
     );
-    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::try_from_iter_with_config(dataset.into_iter().map(Ok), lc_config).expect("failed to instantiate LC tree [lc_instantiate_try_from_iter_with_config]");
+    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::try_from_iter_with_config(dataset.into_iter().map(Ok), lc_config).expect("failed to instantiate LC tree [lc_instantiate_try_from_iter_with_config]");
     tree.set_external_reader_path(&replica_path)
         .expect("can't set external reader path [lc_instantiate_try_from_iter_with_config]");
     tree
@@ -138,12 +137,12 @@ fn lc_instantiate_try_from_iter_with_config<
 fn lc_instantiate_from_par_iter_with_config<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
 >(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_vector_of_elements::<E>(leaves);
 
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -158,13 +157,13 @@ fn lc_instantiate_from_par_iter_with_config<
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::from_par_iter_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::from_par_iter_with_config(
         dataset.clone(),
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_from_par_iter_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -177,17 +176,21 @@ fn lc_instantiate_from_par_iter_with_config<
         format!("{}-{}", "lc_instantiate_from_par_iter_with_config", "lc"),
         Some(tree.len()),
     );
-    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::from_par_iter_with_config(dataset, lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_par_iter_with_config]");
+    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::from_par_iter_with_config(dataset, lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_par_iter_with_config]");
     tree.set_external_reader_path(&replica_path)
         .expect("can't set external reader path [lc_instantiate_from_par_iter_with_config]");
     tree
 }
 
-fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
+fn lc_instantiate_from_data_with_config<
+    E: Element,
+    A: Algorithm<E>,
+    const BASE_TREE_ARITY: usize,
+>(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_vector_of_usizes(leaves);
 
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -202,13 +205,13 @@ fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeAri
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::from_data_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::from_data_with_config(
         dataset.as_slice(),
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_from_data_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -221,7 +224,7 @@ fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeAri
         format!("{}-{}", "lc_instantiate_from_data_with_config", "lc"),
         Some(tree.len()),
     );
-    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::from_data_with_config(dataset.as_slice(), lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_data_with_config]");
+    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::from_data_with_config(dataset.as_slice(), lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_data_with_config]");
     tree.set_external_reader_path(&replica_path)
         .expect("can't set external reader path [lc_instantiate_from_data_with_config]");
     tree
@@ -230,12 +233,12 @@ fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeAri
 fn lc_instantiate_from_byte_slice_with_config<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
 >(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_byte_slice_tree::<E, A>(leaves);
 
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -250,13 +253,13 @@ fn lc_instantiate_from_byte_slice_with_config<
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::from_byte_slice_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::from_byte_slice_with_config(
         dataset.as_slice(),
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_from_byte_slice_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -269,7 +272,7 @@ fn lc_instantiate_from_byte_slice_with_config<
         format!("{}-{}", "lc_instantiate_from_byte_slice_with_config", "lc"),
         Some(tree.len()),
     );
-    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::from_byte_slice_with_config(dataset.as_slice(), lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_byte_slice_with_config]");
+    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::from_byte_slice_with_config(dataset.as_slice(), lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_byte_slice_with_config]");
     tree.set_external_reader_path(&replica_path)
         .expect("can't set external reader path [lc_instantiate_from_byte_slice_with_config]");
     tree
@@ -279,14 +282,14 @@ fn lc_instantiate_from_byte_slice_with_config<
 fn lc_instantiate_from_tree_slice_with_config<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
 >(
     leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> {
     let dataset = generate_vector_of_usizes(leaves);
-    let tmp_tree = MerkleTree::<E, A, VecStore<E>, BaseTreeArity>::from_data(dataset.as_slice())
+    let tmp_tree = MerkleTree::<E, A, VecStore<E>, BASE_TREE_ARITY>::from_data(dataset.as_slice())
         .expect("failed to instantiate tree [lc_instantiate_from_tree_slice_with_config]");
     let dataset = serialize_tree(tmp_tree);
 
@@ -302,14 +305,14 @@ fn lc_instantiate_from_tree_slice_with_config<
     );
 
     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-    let tree = MerkleTree::<E, A, DiskStore<E>, BaseTreeArity>::from_tree_slice_with_config(
+    let tree = MerkleTree::<E, A, DiskStore<E>, BASE_TREE_ARITY>::from_tree_slice_with_config(
         dataset.as_slice(),
         leaves,
         config.clone(),
     )
     .expect("failed to instantiate tree [lc_instantiate_from_tree_slice_with_config]");
 
-    dump_tree_data_to_replica::<E, BaseTreeArity>(
+    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
         tree.leafs(),
         tree.len(),
         &config,
@@ -322,7 +325,7 @@ fn lc_instantiate_from_tree_slice_with_config<
         format!("{}-{}", "lc_instantiate_from_tree_slice_with_config", "lc"),
         Some(tree.len()),
     );
-    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>::from_tree_slice_with_config(dataset.as_slice(), leaves, lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_tree_slice_with_config]");
+    let mut tree = MerkleTree::<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>::from_tree_slice_with_config(dataset.as_slice(), leaves, lc_config).expect("failed to instantiate LC tree [lc_instantiate_from_tree_slice_with_config]");
     tree.set_external_reader_path(&replica_path)
         .expect("can't set external reader path [lc_instantiate_from_tree_slice_with_config]");
     tree
@@ -330,12 +333,12 @@ fn lc_instantiate_from_tree_slice_with_config<
 
 /// Test executor
 #[allow(clippy::type_complexity)]
-fn run_test_base_lc_tree<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
+fn run_test_base_lc_tree<E: Element, A: Algorithm<E>, const BASE_TREE_ARITY: usize>(
     constructor: fn(
         usize,
         &Path,
         usize,
-    ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>,
+    ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY>,
     leaves_in_tree: usize,
     temp_dir_path: &Path,
     rows_to_discard: usize,
@@ -343,8 +346,8 @@ fn run_test_base_lc_tree<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     expected_len: usize,
     expected_root: E,
 ) {
-    // base tree has SubTreeArity and TopTreeArity parameters equal to zero
-    let tree: MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> =
+    // base tree has SUB_TREE_ARITY and TOP_TREE_ARITY parameters equal to zero
+    let tree: MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY> =
         constructor(leaves_in_tree, temp_dir_path, rows_to_discard);
     test_levelcache_tree_functionality(
         tree,
@@ -364,12 +367,12 @@ fn test_base_levelcache_trees_iterable() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves;
-        let len = get_merkle_tree_len_generic::<U8, U0, U0>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 0, 0>(base_tree_leaves).unwrap();
         let rows_to_discard = 0;
 
         let distinguisher = "lc_instantiate_new_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_new_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -381,7 +384,7 @@ fn test_base_levelcache_trees_iterable() {
 
         let distinguisher = "lc_instantiate_try_from_iter_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_try_from_iter_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -393,7 +396,7 @@ fn test_base_levelcache_trees_iterable() {
 
         let distinguisher = "lc_instantiate_from_par_iter_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_from_par_iter_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -419,12 +422,12 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves;
-        let len = get_merkle_tree_len_generic::<U8, U0, U0>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 0, 0>(base_tree_leaves).unwrap();
         let rows_to_discard = 0;
 
         let distinguisher = "lc_instantiate_from_data_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_from_data_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -436,7 +439,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
 
         let distinguisher = "lc_instantiate_from_byte_slice_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_from_byte_slice_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -449,7 +452,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         /* TODO investigate, why this test fails
         let distinguisher = "lc_instantiate_from_tree_slice_with_config";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
-        run_test_base_lc_tree::<E, A, U8>(
+        run_test_base_lc_tree::<E, A, 8>(
             lc_instantiate_from_tree_slice_with_config,
             base_tree_leaves,
             temp_dir.path(),
@@ -474,25 +477,23 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
 fn lc_instantiate_ctree_from_store_configs_and_replica<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
-    SubTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
+    const SUB_TREE_ARITY: usize,
 >(
     base_tree_leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity> {
+) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BASE_TREE_ARITY, SUB_TREE_ARITY> {
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
     let mut replica_file = std::fs::File::create(&replica_path).expect(
         "failed to create replica file [lc_instantiate_ctree_from_store_configs_and_replica]",
     );
 
-    let sub_tree_arity = SubTreeArity::to_usize();
-
-    let offsets = (0..sub_tree_arity)
+    let offsets = (0..SUB_TREE_ARITY)
         .map(|index| index * E::byte_len() * base_tree_leaves)
         .collect();
 
-    let configs = (0..sub_tree_arity)
+    let configs = (0..SUB_TREE_ARITY)
         .map(|index| {
             // prepare replica file content
             let config = StoreConfig::new(
@@ -502,11 +503,11 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
                     .expect("can't get rows_to_discard [lc_instantiate_ctree_from_store_configs_and_replica]"),
             );
             // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
-            let tree = instantiate_new_with_config::<E, A, DiskStore<E>, BaseTreeArity>(
+            let tree = instantiate_new_with_config::<E, A, DiskStore<E>, BASE_TREE_ARITY>(
                 base_tree_leaves,
                 Some(config.clone()),
             );
-            dump_tree_data_to_replica::<E, BaseTreeArity>(
+            dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
                 tree.leafs(),
                 tree.len(),
                 &config,
@@ -523,7 +524,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
                 E,
                 A,
                 LevelCacheStore<E, std::fs::File>,
-                BaseTreeArity,
+                BASE_TREE_ARITY,
             >(base_tree_leaves, Some(lc_config.clone()));
             tree.set_external_reader_path(&replica_path)
                 .expect("can't set external reader path [lc_instantiate_ctree_from_store_configs_and_replica]");
@@ -548,18 +549,18 @@ fn test_compound_levelcache_trees() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves * 8;
-        let len = get_merkle_tree_len_generic::<U8, U8, U0>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 8, 0>(base_tree_leaves).unwrap();
 
         let distinguisher = "instantiate_cctree_from_sub_tree_store_configs_and_replica";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
         let rows_to_discard = 0;
-        let tree = lc_instantiate_ctree_from_store_configs_and_replica::<E, A, U8, U8>(
+        let tree = lc_instantiate_ctree_from_store_configs_and_replica::<E, A, 8, 8>(
             base_tree_leaves,
             temp_dir.path(),
             Some(rows_to_discard),
         );
 
-        test_levelcache_tree_functionality::<E, A, U8, U8, U0>(
+        test_levelcache_tree_functionality::<E, A, 8, 8, 0>(
             tree,
             Some(rows_to_discard),
             expected_total_leaves,
@@ -581,29 +582,32 @@ fn test_compound_levelcache_trees() {
 fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
     E: Element,
     A: Algorithm<E>,
-    BaseTreeArity: Unsigned,
-    SubTreeArity: Unsigned,
-    TopTreeArity: Unsigned,
+    const BASE_TREE_ARITY: usize,
+    const SUB_TREE_ARITY: usize,
+    const TOP_TREE_ARITY: usize,
 >(
     base_tree_leaves: usize,
     temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
-) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity, TopTreeArity>
-{
+) -> MerkleTree<
+    E,
+    A,
+    LevelCacheStore<E, std::fs::File>,
+    BASE_TREE_ARITY,
+    SUB_TREE_ARITY,
+    TOP_TREE_ARITY,
+> {
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
     let mut replica_file = std::fs::File::create(&replica_path)
         .expect("failed to create replica file [lc_instantiate_cctree_from_sub_tree_store_configs_and_replica]");
 
-    let sub_tree_arity = SubTreeArity::to_usize();
-    let top_tree_arity = TopTreeArity::to_usize();
-
-    let offsets = (0..sub_tree_arity * top_tree_arity)
+    let offsets = (0..SUB_TREE_ARITY * TOP_TREE_ARITY)
         .map(|index| index * E::byte_len() * base_tree_leaves)
         .collect();
 
-    let configs = (0..TopTreeArity::to_usize())
+    let configs = (0..TOP_TREE_ARITY)
         .flat_map(|j| {
-            (0..SubTreeArity::to_usize())
+            (0..SUB_TREE_ARITY)
                 .map(|i| {
                     // prepare replica file content
                     let config = StoreConfig::new(
@@ -619,11 +623,11 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                     );
                     // instantiation of this temp tree is required for binding config to actual file on disk for subsequent dumping the data to replica
                     let tree =
-                        instantiate_new_with_config::<E, A, DiskStore<E>, BaseTreeArity>(
+                        instantiate_new_with_config::<E, A, DiskStore<E>, BASE_TREE_ARITY>(
                             base_tree_leaves,
                             Some(config.clone()),
                         );
-                    dump_tree_data_to_replica::<E, BaseTreeArity>(
+                    dump_tree_data_to_replica::<E, BASE_TREE_ARITY>(
                         tree.leafs(),
                         tree.len(),
                         &config,
@@ -644,7 +648,7 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                         E,
                         A,
                         LevelCacheStore<E, std::fs::File>,
-                        BaseTreeArity,
+                        BASE_TREE_ARITY,
                     >(base_tree_leaves, Some(lc_config.clone()));
                     tree.set_external_reader_path(&replica_path).expect(
                         "can't set external reader path [lc_instantiate_cctree_from_sub_tree_store_configs_and_replica]",
@@ -672,18 +676,18 @@ fn test_compound_compound_levelcache_trees() {
     fn run_tests<E: Element + Copy, A: Algorithm<E>>(root: E) {
         let base_tree_leaves = 64;
         let expected_total_leaves = base_tree_leaves * 8 * 2;
-        let len = get_merkle_tree_len_generic::<U8, U8, U2>(base_tree_leaves).unwrap();
+        let len = get_merkle_tree_len_generic::<8, 8, 2>(base_tree_leaves).unwrap();
 
         let distinguisher = "instantiate_cctree_from_sub_tree_store_configs_and_replica";
         let temp_dir = tempdir::TempDir::new(distinguisher).unwrap();
         let rows_to_discard = 0;
-        let tree = lc_instantiate_cctree_from_sub_tree_store_configs_and_replica::<E, A, U8, U8, U2>(
+        let tree = lc_instantiate_cctree_from_sub_tree_store_configs_and_replica::<E, A, 8, 8, 2>(
             base_tree_leaves,
             temp_dir.path(),
             Some(rows_to_discard),
         );
 
-        test_levelcache_tree_functionality::<E, A, U8, U8, U2>(
+        test_levelcache_tree_functionality::<E, A, 8, 8, 2>(
             tree,
             Some(rows_to_discard),
             expected_total_leaves,


### PR DESCRIPTION
This is a low-priority "modernization" PR:

- Fix automatic lints.
- Switch to const generics
- Benchmark with criterion
- Switch to stable and updated rust
- Move testing deps to dev-dependencies

The switch to const generics, and some of the lint fixes are breaking changes, but I figured I'd push this and have it ready in case someone else gets bored and wants to go on a rust cleanup quest.