### PR TITLE
chore: fix lints and nits

### DIFF
--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -1,5 +1,5 @@
 use std::marker::PhantomData;
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use anyhow::{Context, Result};
@@ -209,7 +209,7 @@ impl<
     MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity, TopTreeArity>
 {
     /// Given a pathbuf, instantiate an ExternalReader and set it for the LevelCacheStore.
-    pub fn set_external_reader_path(&mut self, path: &PathBuf) -> Result<()> {
+    pub fn set_external_reader_path(&mut self, path: &Path) -> Result<()> {
         ensure!(self.data.store_mut().is_some(), "store data required");
 
         self.data
@@ -445,7 +445,7 @@ impl<
             is_merkle_tree_size_valid(leafs, branches),
             "MerkleTree size is invalid given the arity"
         );
-        let store = S::new_from_slice(tree_len, &data).context("failed to create data store")?;
+        let store = S::new_from_slice(tree_len, data).context("failed to create data store")?;
         let root = store.read_at(store.len() - 1)?;
 
         Ok(MerkleTree {
@@ -490,7 +490,7 @@ impl<
             "MerkleTree size is invalid given the arity"
         );
 
-        let store = S::new_from_slice_with_config(tree_len, branches, &data, config)
+        let store = S::new_from_slice_with_config(tree_len, branches, data, config)
             .context("failed to create data store")?;
         let root = store.read_at(store.len() - 1)?;
 
@@ -522,11 +522,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 
@@ -587,11 +587,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 
@@ -646,11 +646,11 @@ impl<
         ensure!(
             trees
                 .iter()
-                .all(|ref mt| mt.row_count() == trees[0].row_count()),
+                .all(|mt| mt.row_count() == trees[0].row_count()),
             "All passed in trees must have the same row_count"
         );
         ensure!(
-            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            trees.iter().all(|mt| mt.len() == trees[0].len()),
             "All passed in trees must have the same length"
         );
 

--- a/src/store/disk.rs
+++ b/src/store/disk.rs
@@ -375,7 +375,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
                 let hashed_nodes_as_bytes = chunk_nodes.chunks(branches).fold(
                     Vec::with_capacity(nodes_size),
                     |mut acc, nodes| {
-                        let h = A::default().multi_node(&nodes, level);
+                        let h = A::default().multi_node(nodes, level);
                         acc.extend_from_slice(h.as_ref());
                         acc
                     },

--- a/src/store/level_cache.rs
+++ b/src/store/level_cache.rs
@@ -464,7 +464,7 @@ impl<E: Element, R: Read + Send + Sync> Store<E> for LevelCacheStore<E, R> {
                 let hashed_nodes_as_bytes = chunk_nodes.chunks(branches).fold(
                     Vec::with_capacity(nodes_size),
                     |mut acc, nodes| {
-                        let h = A::default().multi_node(&nodes, level);
+                        let h = A::default().multi_node(nodes, level);
                         acc.extend_from_slice(h.as_ref());
                         acc
                     },

--- a/src/store/vec.rs
+++ b/src/store/vec.rs
@@ -64,7 +64,7 @@ impl<E: Element> Store<E> for VecStore<E> {
         data: &[u8],
         _config: StoreConfig,
     ) -> Result<Self> {
-        Self::new_from_slice(size, &data)
+        Self::new_from_slice(size, data)
     }
 
     fn new_from_slice(size: usize, data: &[u8]) -> Result<Self> {

--- a/src/test_cmh.rs
+++ b/src/test_cmh.rs
@@ -10,6 +10,7 @@ use crate::test_item::Item;
 
 /// Custom merkle hash util test
 #[derive(Debug, Clone, Default)]
+#[allow(clippy::upper_case_acronyms)]
 struct CMH(DefaultHasher);
 
 impl CMH {

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -134,7 +134,7 @@ impl Algorithm<Item> for Sha256Hasher {
         if item_size < hash_output.len() {
             result.copy_from_slice(&hash_output.as_slice()[0..item_size]);
         } else {
-            result.copy_from_slice(&hash_output.as_slice())
+            result.copy_from_slice(hash_output.as_slice())
         }
         result
     }

--- a/src/test_item.rs
+++ b/src/test_item.rs
@@ -44,9 +44,9 @@ impl From<u64> for Item {
     }
 }
 
-impl Into<u64> for Item {
-    fn into(self) -> u64 {
-        self.0
+impl From<Item> for u64 {
+    fn from(x: Item) -> u64 {
+        x.0
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -114,7 +114,7 @@ impl Default for TestXOR128 {
 
 impl Algorithm<TestItem> for TestXOR128 {
     fn hash(&mut self) -> TestItem {
-        self.data.clone()
+        self.data
     }
 }
 
@@ -168,7 +168,7 @@ impl Algorithm<TestItem> for TestSha256Hasher {
                 .0
                 .copy_from_slice(&hash_output.as_slice()[0..item_size]);
         } else {
-            result.0.copy_from_slice(&hash_output.as_slice())
+            result.0.copy_from_slice(hash_output.as_slice())
         }
         result
     }
@@ -211,11 +211,10 @@ pub fn generate_byte_slice_tree<E: Element, A: Algorithm<E>>(leaves: usize) -> V
             a.hash()
         })
         .take(leaves)
-        .map(|item| {
+        .flat_map(|item| {
             a2.reset();
             a2.leaf(item).as_ref().to_vec()
         })
-        .flatten()
         .collect();
 
     dataset

--- a/tests/test_arities.rs
+++ b/tests/test_arities.rs
@@ -130,7 +130,7 @@ fn test_compound_compound_tree_arities() {
             .unwrap();
 
         let base_trees = (0..TopTreeArity::to_usize())
-            .map(|_| {
+            .flat_map(|_| {
                 get_vector_of_base_trees::<
                     TestItemType,
                     TestSha256Hasher,
@@ -139,7 +139,6 @@ fn test_compound_compound_tree_arities() {
                     SubTreeArity,
                 >(leaves)
             })
-            .flatten()
             .collect::<Vec<MerkleTree<_, _, _, BaseTreeArity>>>();
 
         let tree = MerkleTree::from_sub_trees_as_trees(base_trees).expect(

--- a/tests/test_compound_compound_constructors.rs
+++ b/tests/test_compound_compound_constructors.rs
@@ -47,12 +47,11 @@ fn instantiate_cctree_from_sub_trees_as_trees<
     base_tree_leaves: usize,
 ) -> MerkleTree<E, A, S, BaseTreeArity, SubTreeArity, TopTreeArity> {
     let base_trees = (0..TopTreeArity::to_usize())
-        .map(|_| {
+        .flat_map(|_| {
             (0..SubTreeArity::to_usize())
                 .map(|_| instantiate_new(base_tree_leaves, None))
                 .collect::<Vec<MerkleTree<E, A, S, BaseTreeArity, U0, U0>>>()
         })
-        .flatten()
         .collect();
 
     MerkleTree::from_sub_trees_as_trees(base_trees)
@@ -78,16 +77,12 @@ fn instantiate_cctree_from_sub_tree_store_configs<
         .expect("can't get tree len [instantiate_cctree_from_sub_tree_store_configs]");
 
     let configs = (0..TopTreeArity::to_usize())
-        .map(|j| {
+        .flat_map(|j| {
             (0..SubTreeArity::to_usize())
                 .map(|i| {
                     let replica = format!(
                         "{}-{}-{}-{}-{}-replica",
-                        distinguisher,
-                        i.to_string(),
-                        j.to_string(),
-                        base_tree_leaves,
-                        len,
+                        distinguisher, i, j, base_tree_leaves, len,
                     );
 
                     // we attempt to discard all intermediate layers, except bottom one (set of leaves) and top-level root of base tree
@@ -101,7 +96,6 @@ fn instantiate_cctree_from_sub_tree_store_configs<
                 })
                 .collect::<Vec<StoreConfig>>()
         })
-        .flatten()
         .collect::<Vec<StoreConfig>>();
 
     MerkleTree::from_sub_tree_store_configs(base_tree_leaves, &configs)

--- a/tests/test_compound_constructors.rs
+++ b/tests/test_compound_constructors.rs
@@ -123,11 +123,7 @@ fn instantiate_ctree_from_store_configs<
         .map(|index| {
             let replica = format!(
                 "{}-{}-{}-{}-{}-replica",
-                distinguisher,
-                index.to_string(),
-                base_tree_leaves,
-                len,
-                row_count,
+                distinguisher, index, base_tree_leaves, len, row_count,
             );
 
             let config = StoreConfig::new(

--- a/tests/test_levelcache_trees.rs
+++ b/tests/test_levelcache_trees.rs
@@ -23,7 +23,7 @@
 /// those items and dumping data to filesystem
 pub mod common;
 
-use std::path::PathBuf;
+use std::path::Path;
 
 use merkletree::hash::Algorithm;
 use merkletree::merkle::{
@@ -41,7 +41,7 @@ use crate::common::{
 /// LevelCacheStore constructors of base trees
 fn lc_instantiate_new_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -93,7 +93,7 @@ fn lc_instantiate_try_from_iter_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -141,7 +141,7 @@ fn lc_instantiate_from_par_iter_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_elements::<E>(leaves);
@@ -185,7 +185,7 @@ fn lc_instantiate_from_par_iter_with_config<
 
 fn lc_instantiate_from_data_with_config<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_usizes(leaves);
@@ -233,7 +233,7 @@ fn lc_instantiate_from_byte_slice_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_byte_slice_tree::<E, A>(leaves);
@@ -282,7 +282,7 @@ fn lc_instantiate_from_tree_slice_with_config<
     BaseTreeArity: Unsigned,
 >(
     leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity> {
     let dataset = generate_vector_of_usizes(leaves);
@@ -329,14 +329,15 @@ fn lc_instantiate_from_tree_slice_with_config<
 }
 
 /// Test executor
+#[allow(clippy::type_complexity)]
 fn run_test_base_lc_tree<E: Element, A: Algorithm<E>, BaseTreeArity: Unsigned>(
     constructor: fn(
         usize,
-        &PathBuf,
+        &Path,
         usize,
     ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity>,
     leaves_in_tree: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: usize,
     expected_leaves: usize,
     expected_len: usize,
@@ -371,7 +372,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_new_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -383,7 +384,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_try_from_iter_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -395,7 +396,7 @@ fn test_base_levelcache_trees_iterable() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_par_iter_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -426,7 +427,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_data_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -438,7 +439,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_byte_slice_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -451,7 +452,7 @@ fn test_base_levelcache_trees_iterable_hashable_and_serialization() {
         run_test_base_lc_tree::<E, A, U8>(
             lc_instantiate_from_tree_slice_with_config,
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             rows_to_discard,
             expected_total_leaves,
             len,
@@ -477,7 +478,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
     SubTreeArity: Unsigned,
 >(
     base_tree_leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity> {
     let replica_path = StoreConfig::data_path(temp_dir_path, "replica_path");
@@ -496,7 +497,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
             // prepare replica file content
             let config = StoreConfig::new(
                 temp_dir_path,
-                format!("{}{}", String::from("config_id"), index.to_string()),
+                format!("config_id{}", index),
                 rows_to_discard
                     .expect("can't get rows_to_discard [lc_instantiate_ctree_from_store_configs_and_replica]"),
             );
@@ -515,7 +516,7 @@ fn lc_instantiate_ctree_from_store_configs_and_replica<
             // generate valid configs and bind them each to actual data of the tree
             let lc_config = StoreConfig::from_config(
                 &config,
-                format!("{}{}", String::from("lc_config_id"), index.to_string()),
+                format!("lc_config_id{}", index),
                 Some(tree.len()),
             );
             let mut tree = instantiate_new_with_config::<
@@ -554,7 +555,7 @@ fn test_compound_levelcache_trees() {
         let rows_to_discard = 0;
         let tree = lc_instantiate_ctree_from_store_configs_and_replica::<E, A, U8, U8>(
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             Some(rows_to_discard),
         );
 
@@ -585,7 +586,7 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
     TopTreeArity: Unsigned,
 >(
     base_tree_leaves: usize,
-    temp_dir_path: &PathBuf,
+    temp_dir_path: &Path,
     rows_to_discard: Option<usize>,
 ) -> MerkleTree<E, A, LevelCacheStore<E, std::fs::File>, BaseTreeArity, SubTreeArity, TopTreeArity>
 {
@@ -601,17 +602,16 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
         .collect();
 
     let configs = (0..TopTreeArity::to_usize())
-        .map(|j| {
+        .flat_map(|j| {
             (0..SubTreeArity::to_usize())
                 .map(|i| {
                     // prepare replica file content
                     let config = StoreConfig::new(
                         temp_dir_path,
                         format!(
-                            "{}{}{}",
-                            String::from("config_id"),
-                            i.to_string(),
-                            j.to_string()
+                            "config_id{}{}",
+                            i,
+                            j
                         ),
                         rows_to_discard.expect(
                             "can't get rows_to_discard [lc_instantiate_cctree_from_sub_tree_store_configs_and_replica]",
@@ -634,10 +634,9 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                     let lc_config = StoreConfig::from_config(
                         &config,
                         format!(
-                            "{}{}{}",
-                            String::from("lc_config_id"),
-                            i.to_string(),
-                            j.to_string()
+                            "lc_config_id{}{}",
+                            i,
+                            j
                         ),
                         Some(tree.len()),
                     );
@@ -654,7 +653,6 @@ fn lc_instantiate_cctree_from_sub_tree_store_configs_and_replica<
                 })
                 .collect::<Vec<StoreConfig>>()
         })
-        .flatten()
         .collect::<Vec<StoreConfig>>();
 
     MerkleTree::from_sub_tree_store_configs_and_replica(
@@ -681,7 +679,7 @@ fn test_compound_compound_levelcache_trees() {
         let rows_to_discard = 0;
         let tree = lc_instantiate_cctree_from_sub_tree_store_configs_and_replica::<E, A, U8, U8, U2>(
             base_tree_leaves,
-            &temp_dir.as_ref().to_path_buf(),
+            temp_dir.path(),
             Some(rows_to_discard),
         );
 


### PR DESCRIPTION
- Fix clippy lints
- Take `&Path` instead of `&PathBuf` in APIs.
- Avoid unnecessary `to_string()` calls.

BREAKING: Taking `&Path` in APIs is technically breaking, but should have negligible fallout.

Q: Are we OK with the API breaking changes? Given autoderef, I don't expect an issue.