### PR TITLE
security: change dep rust-crypto -> sha2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,17 @@ version = "0.22.0"
 authors = [
   "nemo <nemo@protocol.ai>",
   "schomatis",
-  "Ivan Prisyazhnyy <john.koepi@gmail.com>"
+  "Ivan Prisyazhnyy <john.koepi@gmail.com>",
 ]
 
-description   = "Light merkle tree implementation with SPV support and dependency agnostic."
-license       = "BSD-3-Clause"
-homepage      = "https://github.com/filecoin-project/merkle_light"
-repository    = "https://github.com/filecoin-project/merkle_light"
+readme = "README.md"
+description = "Light merkle tree implementation with SPV support and dependency agnostic."
+license = "BSD-3-Clause"
+homepage = "https://github.com/filecoin-project/merkle_light"
+repository = "https://github.com/filecoin-project/merkle_light"
 documentation = "https://docs.rs/merkletree"
-readme        = "README.md"
-keywords      = ["merkle", "merkle-tree"]
-categories    = ["data-structures", "cryptography"]
+keywords = ["merkle", "merkle-tree"]
+categories = ["data-structures", "cryptography"]
 edition = "2018"
 
 [package.metadata.release]
@@ -28,14 +28,14 @@ arrayref = "0.3.5"
 tempfile = "3.0.7"
 positioned-io = "0.2"
 log = "0.4.7"
-serde = { version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0.23"
 typenum = "1.11.2"
 
 [dev-dependencies]
 byteorder = "1.3.1"
 env_logger = "0.7.1"
-rust-crypto = "^0.2.36"
+sha2 = "0.10.2"
 tempdir = "0.3.7"
 rand = "0.7.3"
 criterion = "0.3"

--- a/src/test_common.rs
+++ b/src/test_common.rs
@@ -1,12 +1,11 @@
 #![cfg(test)]
 #![cfg(not(tarpaulin_include))]
 
+use sha2::{Digest, Sha256};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hasher;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
 use typenum::marker_traits::Unsigned;
 
 use crate::hash::Algorithm;
@@ -86,7 +85,7 @@ impl Element for [u8; 16] {
 /// Implementation of SHA-256 Hasher
 ///
 /// It is used for testing purposes
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct Sha256Hasher {
     engine: Sha256,
 }
@@ -120,7 +119,7 @@ impl Hasher for Sha256Hasher {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        self.engine.input(bytes)
+        self.engine.update(bytes)
     }
 }
 
@@ -128,8 +127,7 @@ impl Algorithm<Item> for Sha256Hasher {
     fn hash(&mut self) -> Item {
         let mut result: Item = Item::default();
         let item_size = result.len();
-        let mut hash_output = vec![0u8; self.engine.output_bytes()];
-        self.engine.result(&mut hash_output);
+        let hash_output = self.engine.clone().finalize().to_vec();
         self.engine.reset();
         if item_size < hash_output.len() {
             result.copy_from_slice(&hash_output.as_slice()[0..item_size]);

--- a/src/test_xor128.rs
+++ b/src/test_xor128.rs
@@ -7,9 +7,8 @@ use std::num::ParseIntError;
 use std::os::unix::prelude::FileExt;
 use std::path::Path;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
 use rayon::iter::{plumbing::Producer, IntoParallelIterator, ParallelIterator};
+use sha2::{Digest, Sha256};
 use typenum::marker_traits::Unsigned;
 use typenum::{U2, U3, U4, U5, U7, U8};
 
@@ -355,11 +354,10 @@ fn test_hasher_light() {
     let mut sha256 = Sha256::new();
     let number_of_hashing = 951;
     let input = decode_hex("000102030405060708090a0b0c0d0e0f").unwrap();
-    let mut expected_output = vec![0u8; sha256.output_bytes()];
     for _ in 0..number_of_hashing {
-        sha256.input(input.as_slice());
+        sha256.update(input.as_slice());
     }
-    sha256.result(expected_output.as_mut_slice());
+    let mut expected_output = sha256.finalize().to_vec();
     expected_output.truncate(Item::byte_len());
 
     run_test::<Item, Sha256Hasher>(number_of_hashing, input, expected_output);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -161,7 +161,6 @@ impl Algorithm<TestItem> for TestSha256Hasher {
         let item_size = result.0.len();
         let hash_output = self.engine.clone().finalize().to_vec();
         self.engine.reset();
-        self.engine.reset();
         if item_size < hash_output.len() {
             result
                 .0

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,8 +3,7 @@ use std::fmt;
 use std::hash::Hasher;
 use std::io::Write;
 
-use crypto::digest::Digest;
-use crypto::sha2::Sha256;
+use sha2::{Digest, Sha256};
 use typenum::Unsigned;
 
 use merkletree::hash::{Algorithm, Hashable};
@@ -152,7 +151,7 @@ impl Hasher for TestSha256Hasher {
     }
 
     fn write(&mut self, bytes: &[u8]) {
-        self.engine.input(bytes)
+        self.engine.update(bytes)
     }
 }
 
@@ -160,8 +159,8 @@ impl Algorithm<TestItem> for TestSha256Hasher {
     fn hash(&mut self) -> TestItem {
         let mut result = TestItem::default();
         let item_size = result.0.len();
-        let mut hash_output = vec![0u8; self.engine.output_bytes()];
-        self.engine.result(&mut hash_output);
+        let hash_output = self.engine.clone().finalize().to_vec();
+        self.engine.reset();
         self.engine.reset();
         if item_size < hash_output.len() {
             result


### PR DESCRIPTION
rust-crypto is unmaintained:
https://rustsec.org/advisories/RUSTSEC-2016-0005.html
https://rustsec.org/advisories/RUSTSEC-2022-0011.html

it's risk describle in https://github.com/filecoin-project/merkletree/issues/110