### PR TITLE
Update the positioned-io dependency to the 0.3 version (from 0.2)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rayon = "1.0.0"
 memmap2 = "0.5.7"
 arrayref = "0.3.5"
 tempfile = "3.3"
-positioned-io = "0.2"
+positioned-io = "0.3"
 log = "0.4.7"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0.23"


### PR DESCRIPTION
The `positioned-io` crate previously used outdated versions of `byteorder` and `winapy` crates. So this pull request along with the fixed #17 issue updates all dependencies that I'm aware of.