### PR TITLE
fix: Allow construction of stores from read-only files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ sha2 = "0.10.2"
 tempfile = "3.3"
 rand = "0.7.3"
 criterion = "0.3"
+walkdir = "2.3.2"
 
 [[bench]]
 name = "merkle"

--- a/src/store/disk.rs
+++ b/src/store/disk.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 
 use anyhow::{Context, Result};
+use log::warn;
 use memmap2::MmapOptions;
 use positioned_io::{ReadAt, WriteAt};
 use rayon::iter::*;
@@ -129,7 +130,23 @@ impl<E: Element> Store<E> for DiskStore<E> {
     fn new_from_disk(size: usize, _branches: usize, config: &StoreConfig) -> Result<Self> {
         let data_path = StoreConfig::data_path(&config.path, &config.id);
 
-        let file = OpenOptions::new().write(true).read(true).open(data_path)?;
+        ensure!(Path::new(&data_path).exists(), "[DiskStore] new_from_disk constructor can be used only for instantiating already existing storages");
+
+        let file = match OpenOptions::new().write(true).read(true).open(&data_path) {
+            Ok(file) => file,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::PermissionDenied {
+                    warn!(
+                        "[DiskStore] Permission denied occurred. Try to open storage as read-only"
+                    );
+                }
+                OpenOptions::new()
+                    .write(false)
+                    .read(true)
+                    .open(&data_path)?
+            }
+        };
+
         let metadata = file.metadata()?;
         let store_size = metadata.len() as usize;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -212,6 +212,7 @@ pub trait Store<E: Element>: std::fmt::Debug + Send + Sync + Sized {
 
     fn new_from_slice(size: usize, data: &[u8]) -> Result<Self>;
 
+    /// This constructor is used for instantiating stores ONLY from existing (potentially read-only) files
     fn new_from_disk(size: usize, branches: usize, config: &StoreConfig) -> Result<Self>;
 
     fn write_at(&mut self, el: E, index: usize) -> Result<()>;


### PR DESCRIPTION
This PR attempts to fix https://github.com/filecoin-project/rust-fil-proofs/issues/1629. As previously we required storage files to have read/write permissions, it caused errors at high-level when read-only storages were used. 

Now, if there is an "Permission denied" error while opening file in read/write mode, constructor of the storage tries to open file once again in read-only mode. 

A couple of tests are added to cover this (for LevelCacheStore and DiskStore). Note, that MmapStore doesn't work with read-only files, so in this case we just panic. Considering that this type of storage used mostly for testing - this should not be a big problem.