### PR TITLE
Fixes for cargo release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ edition = "2018"
 
 [package.metadata.release]
 pre-release-commit-message = "chore(release): release {{version}}"
-pro-release-commit-message = "chore(release): starting development cycle for {{next_version}}"
 
 [dependencies]
 rayon = "1.0.0"

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,0 @@
-pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
-pro-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
-no-dev-version = true


### PR DESCRIPTION
 - Remove release.toml as it is no longer used for release process

 - Remove pro-release-commit-message as no longer supported by Cargo